### PR TITLE
Some QoL improvements

### DIFF
--- a/MediaSplitter/App.config
+++ b/MediaSplitter/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/MediaSplitter/Arguments.cs
+++ b/MediaSplitter/Arguments.cs
@@ -32,7 +32,7 @@ namespace MediaSplitter
         /// <summary>
         /// The minimum detected black duration (in seconds)
         /// </summary>
-        public double BlackDuration { get; set; } = 0.08;
+        public String BlackDuration { get; set; } = "0.08";
 
         /// <summary>
         /// Threshold for considering a picture as "Black" (in percent).

--- a/MediaSplitter/MediaSplitter.csproj
+++ b/MediaSplitter/MediaSplitter.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MediaSplitter</RootNamespace>
     <AssemblyName>MediaSplitter</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/MediaSplitter/Setup.cs
+++ b/MediaSplitter/Setup.cs
@@ -78,6 +78,12 @@ namespace MediaSplitter
             foreach (MediaFile file in media)
             {
                 Log.WriteHeader($"Checking File \"{file.FileInfo.Name}\"");
+                if (file.EpisodeCount == 1)
+                {
+                    Log.WriteLine($"Skipping single episode");
+                    continue;
+                }
+
                 FFmpeg ffmpeg = new FFmpeg();
                 ffmpeg.OnFileRenamed += (originalName, newName) =>
                 {
@@ -96,16 +102,22 @@ namespace MediaSplitter
                 else
                 {
                     Log.WriteLine($"Using BlackScreenDetection to try to find the optimal place to cut.");
-                    var output = ffmpeg.BlackScreenInfo(file.FileInfo.FullName, Arguments.BlackDuration, Arguments.BlackThreshold, Arguments.BlackPixelLuminance).ToList();
+                    var output = ffmpeg.BlackScreenInfo(file.FileInfo.FullName, double.Parse(Arguments.BlackDuration), Arguments.BlackThreshold, Arguments.BlackPixelLuminance).ToList();
                     file.BlackScreenInfo.AddRange(this.CleanBlackScreenInfo(output));
+
+                    if (file.BlackScreenInfo.Count == 0)
+                    {
+                        Log.WriteLine($"No black screens found in file: {file.FileInfo.Name}, Does the break happen inside between {Arguments.StartRange} and {Arguments.EndRange}?");
+                        continue;
+                    }
 
                     foreach (var item in file.BlackScreenInfo)
                     {
                         Log.WriteLine($"[BlackScreen] Start: {item.StartTime} End: {item.EndTime} Duration: {item.Duration}");
                     }
-                    
+
                     // Since 2 episodes should have 1 cut, and 3 episodes 2 cuts we subtract one.
-                    if(file.BlackScreenInfo.Count > file.EpisodeCount - 1)
+                    if (file.BlackScreenInfo.Count != 0 && file.BlackScreenInfo.Count > file.EpisodeCount - 1)
                     {
                         Log.WriteLine($"The amount of black screens ({file.BlackScreenInfo.Count}) would cut into {file.BlackScreenInfo.Count + 1} files. Expected files is {file.EpisodeCount}.");
                         continue;


### PR DESCRIPTION
First off, thank you for solving this annoying problem with Plex. I updated the .net target frankly because that's what VS wanted me to do, but beyond that I made a few tweaks while I was splitting a show that wasn't super uniform and needed several re-runs of the program. 

I added in a check to skip single episodes instead of trying to reprocess them since they do not need to be split.

I tweaked the argument for BlackDuration to a string to be able to pass it in on the command line.

Finally, I added some clarifying logs for when a black screen is not found in the specified time range.

Figured I'd share back, feel free to merge or not, but thank you again!